### PR TITLE
droprate is a 0-1 scale; use 1.0 for failure

### DIFF
--- a/pkg/ping/ping.go
+++ b/pkg/ping/ping.go
@@ -80,7 +80,7 @@ func runPing(ipAddr string, icmpID int, option *PingOptions) (pingResult PingRes
 
 	if !pingReturn.success {
 		pingResult.Success = false
-		pingResult.DropRate = 100.0
+		pingResult.DropRate = 1.0
 		return pingResult
 	}
 


### PR DESCRIPTION
DropRate is calculated on a 0.0 to 1.0 scale when an ICMP is successful. If it's a failure, the DropRate should be set to 1.0 instead of 100.0 so that the scale remains the same in all cases.