### PR TITLE
add support for SRV records as host

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,38 @@ targets:
 
 **Note:** Domain names are resolved (regularly) to their corresponding A and AAAA records (IPv4 and IPv6).
 By default if not configured, `network_exporter` uses the system resolver to translate domain names to IP addresses.
-You can alos override the DNS resolver address by specifying the `conf.nameserver` configuration setting.
+You can also override the DNS resolver address by specifying the `conf.nameserver` configuration setting.
+
+**SRV records:**  
+If host filed of a target contains SRV record of standard format `_<service>._<protocol>.<domain>`, it will be resolved and all it's A records will be added as separate targets with name and host of the this A record.   
+Every filed of parent target with SRV record will be inherited by sub targets except `name` and `host`
+
+SRV record
+```
+_connectivity-check._icmp.example.com. 86400 IN SRV 10 5 8 server.example.com.
+_connectivity-check._icmp.example.com. 86400 IN SRV 10 5 8 server2.example.com.
+_connectivity-check._icmp.example.com. 86400 IN SRV 10 5 8 server3.example.com.
+```
+Configuration reference
+```
+  - name: test-srv-record
+    host: _connectivity-check._icmp.example.com
+    type: ICMP
+```
+
+Will be resolved to 3 separate targets:
+```
+  - name: server.example.com
+    host: server.example.com
+    type: ICMP
+  - name: server2.example.com
+    host: server.example.com
+    type: ICMP
+  - name: server3.example.com
+    host: server3.example.com
+    type: ICMP
+```
+  
 
 ## Deployment
 

--- a/pkg/common/func.go
+++ b/pkg/common/func.go
@@ -5,8 +5,30 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"strings"
 	"time"
 )
+
+func SrvRecordCheck(record string) bool {
+	record_split := strings.Split(record, ".")
+	if strings.HasPrefix(record_split[0], "_") && strings.HasPrefix(record_split[1], "_") {
+		return true
+	} else {
+		return false
+	}
+}
+
+func SrvRecordHosts(record string) ([]string, error) {
+	_, members, err := net.LookupSRV("", "", record)
+	if err != nil {
+		return nil, fmt.Errorf("Resolving target: %v", err)
+	}
+	hosts := []string{}
+	for _, host := range members {
+		hosts = append(hosts, host.Target)
+	}
+	return hosts, nil
+}
 
 // DestAddrs resolve the hostname to all it'ss IP's
 func DestAddrs(host string, resolver *net.Resolver) ([]string, error) {


### PR DESCRIPTION
Hi,
I would like to add support for SRV records as `host` for a target of network_exporter
I've got it working by extracting target records of SRV record and adding them as separate targets for network_exporter.

few notes:
I had to transform hierarchical `Config` type to inherited in order to be able to call `Targets` type directly. Without it this line `targets := c.Targets[:0]` was messing with original targets from config file during the for loop
And, this is actually my first lines in GO, so I easily imagine that code may look ugly and not "go style". Feel free to correct me.

Let me know if you are interested in this functionality