### PR TITLE
duplicate validation by type, periodical resolving of targets DNS records

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This exporter gathers either ICMP, MTR, TCP Port or HTTP Get stats and exports t
 - IPv4 & IPv6 support
 - Configuration reloading (By interval or OS signal)
 - Dynamically Add or Remove targets without affecting the currently running tests
+- Update of the IP for existing target when DNS resolving changes
 - Targets can be executed on all hosts or a list of specified ones `probe`
 - Configurable logging levels and format (text or json)
 - Configurable DNS Server
@@ -184,12 +185,23 @@ targets:
 By default if not configured, `network_exporter` uses the system resolver to translate domain names to IP addresses.
 You can also override the DNS resolver address by specifying the `conf.nameserver` configuration setting.
 
-**SRV records:**
+**[SRV records](https://en.wikipedia.org/wiki/SRV_record):**  
 If the host field of a target contains a SRV record with the format `_<service>._<protocol>.<domain>` it will be resolved, all it's A records will be added (dynamically) as separate targets with name and host of the this A record.
 Every field of the parent target with a SRV record will be inherited by sub targets except `name` and `host`
 
-SRV record
+SRV record supported for ICMP/MTR/TCP target types.
+TCP SRV record specifcs:
+  - Target type should be `TCP` and `_protocol` part in the SRV record should be `_tcp` as well
+  - Port will be taken from the 3rd number, just before the hostname
 
+TCP SRV example
+```console
+_connectivity-check._tcp.example.com. 86400 IN SRV 10 5 80 server.example.com.
+_connectivity-check._tcp.example.com. 86400 IN SRV 10 5 443 server2.example.com.
+_connectivity-check._tcp.example.com. 86400 IN SRV 10 5 9247 server3.example.com.
+```
+
+ICMP SRV example
 ```console
 _connectivity-check._icmp.example.com. 86400 IN SRV 10 5 8 server.example.com.
 _connectivity-check._icmp.example.com. 86400 IN SRV 10 5 8 server2.example.com.
@@ -202,6 +214,9 @@ Configuration reference
   - name: test-srv-record
     host: _connectivity-check._icmp.example.com
     type: ICMP
+  - name: test-srv-record
+    host: _connectivity-check._tcp_.example.com
+    type: TCP
 ```
 
 Will be resolved to 3 separate targets:
@@ -211,11 +226,20 @@ Will be resolved to 3 separate targets:
     host: server.example.com
     type: ICMP
   - name: server2.example.com
-    host: server.example.com
+    host: server2.example.com
     type: ICMP
   - name: server3.example.com
     host: server3.example.com
     type: ICMP
+  - name: server.example.com:80
+    host: server.example.com:80
+    type: TCP
+  - name: server2.example.com:443
+    host: server2.example.com:443
+    type: TCP
+  - name: server3.example.com:9427
+    host: server3.example.com:9427
+    type: TCP
 ```
 
 ## Deployment

--- a/config/config.go
+++ b/config/config.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/syepes/network_exporter/pkg/common"
 	yaml "gopkg.in/yaml.v3"
 )
@@ -77,7 +80,7 @@ type SafeConfig struct {
 }
 
 // ReloadConfig Safe configuration reload
-func (sc *SafeConfig) ReloadConfig(confFile string) (err error) {
+func (sc *SafeConfig) ReloadConfig(logger log.Logger, confFile string) (err error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		panic(err)
@@ -97,25 +100,33 @@ func (sc *SafeConfig) ReloadConfig(confFile string) (err error) {
 
 	// Validate and Filter config
 	targets := Targets{}
-	var targetNames []string
-
 	for _, t := range c.Targets {
 		if common.SrvRecordCheck(t.Host) {
 			found, _ := regexp.MatchString("^ICMP|MTR|ICMP+MTR|TCP|HTTPGet$", t.Type)
 			if !found {
-				return fmt.Errorf("Target '%s' has unknown check type '%s' must be one of (ICMP|MTR|ICMP+MTR|TCP|HTTPGet)", t.Name, t.Type)
+				level.Error(logger).Log("type", "Config", "func", "ReloadConfig", "msg", fmt.Sprintf("Target '%s' has unknown check type '%s' must be one of (ICMP|MTR|ICMP+MTR|TCP|HTTPGet)", t.Name, t.Type))
+				continue
 			}
+			// Check that SRV record's type is TCP, if config's type is TCP
+			if t.Type == "TCP" {
+				if !strings.EqualFold(t.Type, strings.Split(t.Host, ".")[1][1:]) {
+					level.Error(logger).Log("type", "Config", "func", "ReloadConfig", "msg", fmt.Sprintf("Target %s type '%s' doesn't match SRV record proto '%s'", t.Name, t.Type, strings.Split(t.Host, ".")[1][1:]))
+					continue
+				}
+			}
+
 
 			srv_record_hosts, err := common.SrvRecordHosts(t.Host)
 			if err != nil {
-				return fmt.Errorf((fmt.Sprintf("Error processing SRV target: %s", t.Host)))
+				level.Error(logger).Log("type", "Config", "func", "ReloadConfig", "msg",(fmt.Sprintf("Error processing SRV {target %s}: %s", t.Host, err)))
+				continue
 			}
 
 			for _, srv_host := range srv_record_hosts {
-				targetNames = append(targetNames, srv_host)
+				srvTargetName := srv_host[:len(srv_host) - 1]
 				sub_target := t
-				sub_target.Name = srv_host
-				sub_target.Host = srv_host
+				sub_target.Name = srvTargetName
+				sub_target.Host = srvTargetName
 
 				// Filter out the targets that are not assigned to the running host, if the `probe` is not specified don't filter
 				if sub_target.Probe == nil {
@@ -130,10 +141,10 @@ func (sc *SafeConfig) ReloadConfig(confFile string) (err error) {
 				}
 			}
 		} else {
-			targetNames = append(targetNames, t.Name)
 			found, _ := regexp.MatchString("^ICMP|MTR|ICMP+MTR|TCP|HTTPGet$", t.Type)
 			if !found {
-				return fmt.Errorf("Target '%s' has unknown check type '%s' must be one of (ICMP|MTR|ICMP+MTR|TCP|HTTPGet)", t.Name, t.Type)
+				level.Error(logger).Log("type", "Config", "func", "ReloadConfig", "msg","Target '%s' has unknown check type '%s' must be one of (ICMP|MTR|ICMP+MTR|TCP|HTTPGet)", t.Name, t.Type)
+				continue
 			}
 
 			// Filter out the targets that are not assigned to the running host, if the `probe` is not specified don't filter
@@ -153,8 +164,8 @@ func (sc *SafeConfig) ReloadConfig(confFile string) (err error) {
 	// Remap the filtered targets
 	c.Targets = targets
 
-	if _, err = common.HasListDuplicates(targetNames); err != nil {
-		return fmt.Errorf("Parsing config file: %s", err)
+	if _, err = HasDuplicateTargets(c.Targets); err != nil {
+		return fmt.Errorf("parsing config file: %s", err)
 	}
 
 	// Config precheck
@@ -194,4 +205,22 @@ func (d duration) Duration() time.Duration {
 // Set updates the underlying duration.
 func (d *duration) Set(dur time.Duration) {
 	*d = duration(dur)
+}
+
+// HasDuplicateTargets Find duplicates with same type 
+func HasDuplicateTargets(m Targets) (bool, error) {
+	tmp := map[string]map[string]bool{
+		"TCP": map[string]bool{},
+		"ICMP": map[string]bool{},
+		"MTR": map[string]bool{},
+		"HTTPGet": map[string]bool{},
+	}
+
+	for _,t := range m {
+		if tmp[t.Type][t.Name] {
+			return true, fmt.Errorf("Found duplicated record: %s", t.Name)
+		}
+		tmp[t.Type][t.Name] = true
+	}
+	return false, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -122,11 +122,10 @@ func (sc *SafeConfig) ReloadConfig(logger log.Logger, confFile string) (err erro
 				continue
 			}
 
-			for _, srv_host := range srv_record_hosts {
-				srvTargetName := srv_host[:len(srv_host) - 1]
+			for _, srvTarget := range srv_record_hosts {
 				sub_target := t
-				sub_target.Name = srvTargetName
-				sub_target.Host = srvTargetName
+				sub_target.Name = srvTarget
+				sub_target.Host = srvTarget
 
 				// Filter out the targets that are not assigned to the running host, if the `probe` is not specified don't filter
 				if sub_target.Probe == nil {
@@ -217,10 +216,21 @@ func HasDuplicateTargets(m Targets) (bool, error) {
 	}
 
 	for _,t := range m {
-		if tmp[t.Type][t.Name] {
-			return true, fmt.Errorf("Found duplicated record: %s", t.Name)
+		if t.Type == "ICMP+MTR" {
+			if tmp["MTR"][t.Name] {
+				return true, fmt.Errorf("Found duplicated record: %s", t.Name)
+			}
+			tmp["MTR"][t.Name] = true
+			if tmp["ICMP"][t.Name] {
+				return true, fmt.Errorf("Found duplicated record: %s", t.Name)
+			}
+			tmp["ICMP"][t.Name] = true
+		} else {
+			if tmp[t.Type][t.Name] {
+				return true, fmt.Errorf("Found duplicated record: %s", t.Name)
+			}
+			tmp[t.Type][t.Name] = true
 		}
-		tmp[t.Type][t.Name] = true
 	}
 	return false, nil
 }

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 	level.Info(logger).Log("msg", "Starting network_exporter", "version", version)
 
 	level.Info(logger).Log("msg", "Loading config")
-	if err := sc.ReloadConfig(*configFile); err != nil {
+	if err := sc.ReloadConfig(logger, *configFile); err != nil {
 		level.Error(logger).Log("msg", "Loading config", "err", err)
 		os.Exit(1)
 	}
@@ -88,18 +88,21 @@ func startConfigRefresh() {
 
 	for range time.NewTicker(interval).C {
 		level.Info(logger).Log("msg", "ReLoading config")
-		if err := sc.ReloadConfig(*configFile); err != nil {
+		if err := sc.ReloadConfig(logger, *configFile); err != nil {
 			level.Error(logger).Log("msg", "Reloading config skipped", "err", err)
 			continue
 		} else {
-			monitorPING.AddTargets()
 			monitorPING.DelTargets()
-			monitorMTR.AddTargets()
+			monitorPING.CheckActiveTargets()
+			monitorPING.AddTargets()
 			monitorMTR.DelTargets()
-			monitorTCP.AddTargets()
+			monitorMTR.CheckActiveTargets()
+			monitorMTR.AddTargets()
 			monitorTCP.DelTargets()
-			monitorHTTPGet.AddTargets()
+			monitorTCP.CheckActiveTargets()
+			monitorTCP.AddTargets()
 			monitorHTTPGet.DelTargets()
+			monitorHTTPGet.AddTargets()
 		}
 	}
 }

--- a/monitor/monitor_ping.go
+++ b/monitor/monitor_ping.go
@@ -115,7 +115,7 @@ func (p *PING) CheckActiveTargets() (err error) {
 			}(ipAddrs, targetIp) {
 
 				p.RemoveTarget(targetName)
-				err := p.AddTarget(target.Name, target.Host)
+				err := p.AddTarget(target.Name, target.Host, target.Labels.Kv)
 				if err != nil {
 					level.Warn(p.logger).Log("type", "ICMP", "func", "CheckActiveTargets", "msg", fmt.Sprintf("Skipping target: %s", target.Host), "err", err)
 				}

--- a/pkg/common/func.go
+++ b/pkg/common/func.go
@@ -19,14 +19,25 @@ func SrvRecordCheck(record string) bool {
 }
 
 func SrvRecordHosts(record string) ([]string, error) {
-	_, members, err := net.LookupSRV("", "", record)
+	record_split := strings.Split(record, ".")
+	service :=  record_split[0][1:]
+	proto := record_split[1][1:]
+
+	_, members, err := net.LookupSRV(service, proto, strings.Join(record_split[2:],"."))
 	if err != nil {
-		return nil, fmt.Errorf("Resolving target: %v", err)
+		return nil, fmt.Errorf("resolving target: %v", err)
 	}
 	hosts := []string{}
-	for _, host := range members {
-		hosts = append(hosts, host.Target)
+	if proto == "tcp" {
+		for _, host := range members {
+			hosts = append(hosts,  fmt.Sprintf("%s:%d", host.Target[:len(host.Target) - 1], host.Port))
+		}
+	} else {
+		for _, host := range members {
+			hosts = append(hosts, host.Target[:len(host.Target) - 1])
+		}
 	}
+
 	return hosts, nil
 }
 

--- a/signal.go
+++ b/signal.go
@@ -25,18 +25,21 @@ func reloadSignal() {
 			case <-hup:
 				level.Debug(logger).Log("msg", "Signal: HUP")
 				level.Info(logger).Log("msg", "ReLoading config")
-				if err := sc.ReloadConfig(*configFile); err != nil {
+				if err := sc.ReloadConfig(logger, *configFile); err != nil {
 					level.Error(logger).Log("msg", "Reloading config skipped", "err", err)
 					continue
 				} else {
-					monitorPING.AddTargets()
 					monitorPING.DelTargets()
-					monitorMTR.AddTargets()
+					monitorPING.CheckActiveTargets()
+					monitorPING.AddTargets()
 					monitorMTR.DelTargets()
-					monitorTCP.AddTargets()
+					monitorMTR.CheckActiveTargets()
+					monitorMTR.AddTargets()
 					monitorTCP.DelTargets()
-					monitorHTTPGet.AddTargets()
+					monitorTCP.CheckActiveTargets()
+					monitorTCP.AddTargets()
 					monitorHTTPGet.DelTargets()
+					monitorHTTPGet.AddTargets()
 				}
 			case <-susr:
 				level.Debug(logger).Log("msg", "Signal: USR1")

--- a/signal_windows.go
+++ b/signal_windows.go
@@ -22,18 +22,21 @@ func reloadSignal() {
 			case <-hup:
 				level.Debug(logger).Log("msg", "Signal: HUP")
 				level.Info(logger).Log("msg", "ReLoading config")
-				if err := sc.ReloadConfig(*configFile); err != nil {
+				if err := sc.ReloadConfiglogger, (*configFile); err != nil {
 					level.Error(logger).Log("msg", "Reloading config skipped", "err", err)
 					continue
 				} else {
-					monitorPING.AddTargets()
 					monitorPING.DelTargets()
-					monitorMTR.AddTargets()
+					monitorPING.CheckActiveTargets()
+					monitorPING.AddTargets()
 					monitorMTR.DelTargets()
-					monitorTCP.AddTargets()
+					monitorMTR.CheckActiveTargets()
+					monitorMTR.AddTargets()
 					monitorTCP.DelTargets()
-					monitorHTTPGet.AddTargets()
+					monitorTCP.CheckActiveTargets()
+					monitorTCP.AddTargets()
 					monitorHTTPGet.DelTargets()
+					monitorHTTPGet.AddTargets()
 				}
 			}
 		}

--- a/signal_windows.go
+++ b/signal_windows.go
@@ -22,7 +22,7 @@ func reloadSignal() {
 			case <-hup:
 				level.Debug(logger).Log("msg", "Signal: HUP")
 				level.Info(logger).Log("msg", "ReLoading config")
-				if err := sc.ReloadConfiglogger, (*configFile); err != nil {
+				if err := sc.ReloadConfig(logger, *configFile); err != nil {
 					level.Error(logger).Log("msg", "Reloading config skipped", "err", err)
 					continue
 				} else {


### PR DESCRIPTION
- Add support for SRV record for target type of TCP (logic in readme)
- Add periodical (per ReloadConfig) resolving of targets DNS records for the case when IP may be changed dynamically (k8s  mainly)
- Skip instead of fail on the not correct target (type mismatch or not resolvable DNS)
- Targets duplicate validation per target type instead of all list. So, you can add the same target for ICMP and HTTP tests