### PR TITLE
Many ip from dns for tcp monitor

### DIFF
--- a/collector/collector_tcp.go
+++ b/collector/collector_tcp.go
@@ -55,8 +55,9 @@ func (p *TCP) Collect(ch chan<- prometheus.Metric) {
 	targets := []string{}
 	for target, metric := range p.metrics {
 		targets = append(targets, target)
-		l := strings.SplitN(target, " ", 2)
-		l = append(l, metric.DestAddr)
+		l := strings.SplitN(strings.SplitN(target, " ", 2)[0], " ", 2) // get name without ip and create slice
+		// l = append(l, metric.DestAddr) // removed host from labels metrics
+		l = append(l, metric.DestIp)
 		l = append(l, metric.DestPort)
 		l2 := prometheus.Labels(p.labels[target])
 

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-const version string = "1.5.2"
+const version string = "1.6.0"
 
 var (
 	listenAddress  = kingpin.Flag("web.listen-address", "The address to listen on for HTTP requests").Default(":9427").String()

--- a/pkg/tcp/tcp.go
+++ b/pkg/tcp/tcp.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Port ICMP Operation
-func Port(addr string, port string, interval time.Duration, timeout time.Duration) (*TCPPortReturn, error) {
+func Port(addr string, ip string, port string, interval time.Duration, timeout time.Duration) (*TCPPortReturn, error) {
 	var out TCPPortReturn
 	var err error
 
@@ -16,10 +16,11 @@ func Port(addr string, port string, interval time.Duration, timeout time.Duratio
 	tcpOptions.SetTimeout(timeout)
 
 	out.DestAddr = addr
+	out.DestIp = ip
 	out.DestPort = port
 
 	start := time.Now()
-	conn, err := net.DialTimeout("tcp", net.JoinHostPort(addr, port), tcpOptions.Timeout())
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(ip, port), tcpOptions.Timeout())
 	out.ConTime = time.Since(start)
 
 	if err != nil {

--- a/pkg/tcp/type.go
+++ b/pkg/tcp/type.go
@@ -9,6 +9,7 @@ const defaultInterval = 10 * time.Millisecond
 type TCPPortReturn struct {
 	Success  bool          `json:"success"`
 	DestAddr string        `json:"dest_address"`
+	DestIp   string        `json:"dest_ip"`
 	DestPort string        `json:"dest_port"`
 	ConTime  time.Duration `json:"connection_time"`
 }

--- a/target/target_tcp.go
+++ b/target/target_tcp.go
@@ -16,6 +16,7 @@ type TCPPort struct {
 	logger   log.Logger
 	name     string
 	host     string
+	ip       string
 	port     string
 	interval time.Duration
 	timeout  time.Duration
@@ -27,7 +28,7 @@ type TCPPort struct {
 }
 
 // NewTCPPort starts a new monitoring goroutine
-func NewTCPPort(logger log.Logger, startupDelay time.Duration, name string, host string, port string, interval time.Duration, timeout time.Duration, labels map[string]string) (*TCPPort, error) {
+func NewTCPPort(logger log.Logger, startupDelay time.Duration, name string, host string, ip string, port string, interval time.Duration, timeout time.Duration, labels map[string]string) (*TCPPort, error) {
 	if logger == nil {
 		logger = log.NewNopLogger()
 	}
@@ -35,6 +36,7 @@ func NewTCPPort(logger log.Logger, startupDelay time.Duration, name string, host
 		logger:   logger,
 		name:     name,
 		host:     host,
+		ip:       ip,
 		port:     port,
 		interval: interval,
 		timeout:  timeout,
@@ -74,7 +76,7 @@ func (t *TCPPort) Stop() {
 }
 
 func (t *TCPPort) portCheck() {
-	data, err := tcp.Port(t.host, t.port, t.interval, t.timeout)
+	data, err := tcp.Port(t.host, t.ip, t.port, t.interval, t.timeout)
 	if err != nil {
 		level.Error(t.logger).Log("type", "TCP", "func", "port", "msg", fmt.Sprintf("%s", err))
 	}
@@ -113,6 +115,13 @@ func (t *TCPPort) Host() string {
 	t.RLock()
 	defer t.RUnlock()
 	return t.host
+}
+
+// Ip returns ip
+func (t *TCPPort) Ip() string {
+	t.RLock()
+	defer t.RUnlock()
+	return t.ip
 }
 
 // Labels returns labels


### PR DESCRIPTION
Good day!
I added a mechanism for checking all ip addresses from dns for tcp monitor. Now the unique key for the target is the name + ip, because of this, we had to make a revision to get the ip from resolver.

For example in config:
```
targets:
  - name: www.googleapis.com:443
    host: www.googleapis.com:443
    type: TCP
```

Result:
```
tcp_connection_status{name="www.googleapis.com:443",port="443",target="108.177.14.95"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="142.250.150.95"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="142.251.1.95"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="173.194.221.95"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="173.194.222.95"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="173.194.73.95"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="2a00:1450:4010:c0b::5f"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="2a00:1450:4010:c0d::5f"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="2a00:1450:4010:c0e::5f"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="2a00:1450:4010:c0f::5f"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="64.233.161.95"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="64.233.162.95"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="64.233.164.95"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="64.233.165.95"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="74.125.131.95"} 1
tcp_connection_status{name="www.googleapis.com:443",port="443",target="74.125.205.95"} 1
```