### PR TITLE
Fix ICMP count and cleanup.

### DIFF
--- a/pkg/ping/ping.go
+++ b/pkg/ping/ping.go
@@ -10,13 +10,12 @@ import (
 )
 
 // Ping ICMP Operation
-func Ping(addr string, ip string, srcAddr string, count int, interval time.Duration, timeout time.Duration, icmpID int) (*PingResult, error) {
+func Ping(addr string, ip string, srcAddr string, count int, timeout time.Duration, icmpID int) (*PingResult, error) {
 	var out PingResult
 
 	pingOptions := &PingOptions{}
 	pingOptions.SetCount(count)
 	pingOptions.SetTimeout(timeout)
-	pingOptions.SetInterval(interval)
 
 	out, err := runPing(addr, ip, srcAddr, icmpID, pingOptions)
 	if err != nil {
@@ -26,11 +25,10 @@ func Ping(addr string, ip string, srcAddr string, count int, interval time.Durat
 }
 
 // PingString ICMP Operation
-func PingString(addr string, ip string, srcAddr string, count int, timeout time.Duration, interval time.Duration, icmpID int) (result string, err error) {
+func PingString(addr string, ip string, srcAddr string, count int, timeout time.Duration, icmpID int) (result string, err error) {
 	pingOptions := &PingOptions{}
 	pingOptions.SetCount(count)
 	pingOptions.SetTimeout(timeout)
-	pingOptions.SetInterval(interval)
 
 	var buffer bytes.Buffer
 	buffer.WriteString(fmt.Sprintf("Start %v, PING %v (%v)\n", time.Now().Format("2006-01-02 15:04:05"), addr, addr))
@@ -57,7 +55,6 @@ func runPing(ipAddr string, ip string, srcAddr string, icmpID int, option *PingO
 	// Avoid collisions/interference caused by multiple coroutines initiating mtr
 	pid := icmpID
 	timeout := option.Timeout()
-	interval := option.Interval()
 	ttl := defaultTTL
 	pingReturn := PingReturn{}
 
@@ -83,7 +80,6 @@ func runPing(ipAddr string, ip string, srcAddr string, icmpID int, option *PingO
 		pingReturn.success = true
 
 		seq++
-		time.Sleep(interval)
 	}
 
 	pingResult.Success = pingReturn.success

--- a/pkg/ping/type.go
+++ b/pkg/ping/type.go
@@ -3,7 +3,6 @@ package ping
 import "time"
 
 const defaultTimeout = 5 * time.Second
-const defaultInterval = 10 * time.Millisecond
 const defaultPackerSize = 56
 const defaultCount = 10
 const defaultTTL = 128
@@ -42,7 +41,6 @@ type PingReturn struct {
 type PingOptions struct {
 	count      int
 	timeout    time.Duration
-	interval   time.Duration
 	packetSize int
 }
 
@@ -70,19 +68,6 @@ func (options *PingOptions) Timeout() time.Duration {
 // SetTimeout Setter
 func (options *PingOptions) SetTimeout(timeout time.Duration) {
 	options.timeout = timeout
-}
-
-// Interval Getter
-func (options *PingOptions) Interval() time.Duration {
-	if options.interval == 0 {
-		options.interval = defaultInterval
-	}
-	return options.interval
-}
-
-// SetInterval Setter
-func (options *PingOptions) SetInterval(interval time.Duration) {
-	options.interval = interval
 }
 
 // PacketSize Getter

--- a/pkg/tcp/tcp.go
+++ b/pkg/tcp/tcp.go
@@ -7,13 +7,12 @@ import (
 )
 
 // Port TCP Operation
-func Port(destAddr string, ip string, srcAddr string, port string, interval time.Duration, timeout time.Duration) (*TCPPortReturn, error) {
+func Port(destAddr string, ip string, srcAddr string, port string, timeout time.Duration) (*TCPPortReturn, error) {
 	var out TCPPortReturn
 	var d net.Dialer
 	var err error
 
 	tcpOptions := &TCPPortOptions{}
-	tcpOptions.SetInterval(interval)
 	tcpOptions.SetTimeout(timeout)
 
 	out.DestAddr = destAddr

--- a/pkg/tcp/type.go
+++ b/pkg/tcp/type.go
@@ -3,7 +3,6 @@ package tcp
 import "time"
 
 const defaultTimeout = 5 * time.Second
-const defaultInterval = 10 * time.Millisecond
 
 // TCPPortReturn Calculated results
 type TCPPortReturn struct {
@@ -18,7 +17,6 @@ type TCPPortReturn struct {
 // TCPPortOptions ICMP Options
 type TCPPortOptions struct {
 	timeout  time.Duration
-	interval time.Duration
 }
 
 // Timeout Getter
@@ -32,17 +30,4 @@ func (options *TCPPortOptions) Timeout() time.Duration {
 // SetTimeout Setter
 func (options *TCPPortOptions) SetTimeout(timeout time.Duration) {
 	options.timeout = timeout
-}
-
-// Interval Getter
-func (options *TCPPortOptions) Interval() time.Duration {
-	if options.interval == 0 {
-		options.interval = defaultInterval
-	}
-	return options.interval
-}
-
-// SetInterval Setter
-func (options *TCPPortOptions) SetInterval(interval time.Duration) {
-	options.interval = interval
 }

--- a/target/target_ping.go
+++ b/target/target_ping.go
@@ -90,7 +90,7 @@ func (t *PING) Stop() {
 
 func (t *PING) ping() {
 	icmpID := int(t.icmpID.Get())
-	data, err := ping.Ping(t.host, t.ip, t.srcAddr, t.count, t.interval, t.timeout, icmpID)
+	data, err := ping.Ping(t.host, t.ip, t.srcAddr, t.count, t.timeout, icmpID)
 	if err != nil {
 		level.Error(t.logger).Log("type", "ICMP", "func", "ping", "msg", fmt.Sprintf("%s", err))
 	}

--- a/target/target_tcp.go
+++ b/target/target_tcp.go
@@ -83,7 +83,7 @@ func (t *TCPPort) Stop() {
 }
 
 func (t *TCPPort) portCheck() {
-	data, err := tcp.Port(t.host, t.ip, t.srcAddr, t.port, t.interval, t.timeout)
+	data, err := tcp.Port(t.host, t.ip, t.srcAddr, t.port, t.timeout)
 	if err != nil {
 		level.Error(t.logger).Log("type", "TCP", "func", "port", "msg", fmt.Sprintf("%s", err))
 	}


### PR DESCRIPTION
Hello,

While conducting tests with the exporter, I observed something unusual in my packet capture: it appears that the ICMP check doesn't respect the count and always sends three packets:

```
14:28:45.361446 IP 10.100.3.100 > 10.100.3.1: ICMP echo request, id 1, seq 0, length 13

14:28:50.360774 IP 10.100.3.100 > 10.100.3.1: ICMP echo request, id 2, seq 0, length 13
14:28:50.362169 IP 10.100.3.100 > 10.100.3.1: ICMP echo request, id 1, seq 1, length 13

14:28:55.360262 IP 10.100.3.100 > 10.100.3.1: ICMP echo request, id 3, seq 0, length 13
14:28:55.361605 IP 10.100.3.100 > 10.100.3.1: ICMP echo request, id 2, seq 1, length 13
14:28:55.362916 IP 10.100.3.100 > 10.100.3.1: ICMP echo request, id 1, seq 2, length 13

[...]

14:30:25.380410 IP 10.100.3.100 > 10.100.3.1: ICMP echo request, id 2, seq 19, length 13
14:30:25.380417 IP 10.100.3.100 > 10.100.3.1: ICMP echo request, id 3, seq 18, length 13
14:30:25.380525 IP 10.100.3.100 > 10.100.3.1: ICMP echo request, id 4, seq 0, length 13
```

In reality, it sends one ICMP packet per interval and initiates a new task at each interval until we reach `const MaxConcurrentJobs = 3`, as evident from the `seq` being incremented properly to 19 (count was set to 20).

This pull request addresses that issue, I believe. I also noticed that ICMP and TCP checks differed from the others, and attempted to standardize them/remove what seems to not really be used for interval management. However, this is my first time working with Go, so I'm not entirely sure. I may have missed something or made a mistake.

Thank you.