### PR TITLE
Add support for loading config from HTTP endpoint

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,8 +2,11 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
+	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -89,6 +92,24 @@ type SafeConfig struct {
 	sync.RWMutex
 }
 
+func isHTTPURL(s string) bool {
+	u, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == "http" || u.Scheme == "https"
+}
+
+func parse(data []byte, c *Config) error {
+	err := yaml.Unmarshal(data, &c)
+
+	if err != nil {
+		return fmt.Errorf("unmarshaling config: %s", err)
+	}
+
+	return nil
+}
+
 // ReloadConfig Safe configuration reload
 func (sc *SafeConfig) ReloadConfig(logger *slog.Logger, confFile string) (err error) {
 	hostname, err := os.Hostname()
@@ -96,15 +117,40 @@ func (sc *SafeConfig) ReloadConfig(logger *slog.Logger, confFile string) (err er
 		panic(err)
 	}
 
-	var c = &Config{}
-	f, err := os.Open(confFile)
-	if err != nil {
-		return fmt.Errorf("reading config file: %s", err)
-	}
-	defer f.Close()
+	var data []byte
 
-	decoder := yaml.NewDecoder(f)
-	if err = decoder.Decode(c); err != nil {
+	if isHTTPURL(confFile) {
+		logger.Debug("Loading config from HTTP")
+
+		resp, err := http.Get(confFile)
+		if err != nil {
+			return fmt.Errorf("fetching config file: %s", err)
+		}
+		defer resp.Body.Close()
+
+		data, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("reading config file: %s", err)
+		}
+	} else {
+		logger.Debug("Loading config from file")
+
+		f, err := os.Open(confFile)
+		if err != nil {
+			return fmt.Errorf("reading config file: %s", err)
+		}
+		defer f.Close()
+
+		data, err = io.ReadAll(f)
+		if err != nil {
+			return fmt.Errorf("reading config file: %s", err)
+		}
+	}
+
+	var c = &Config{}
+
+	err = parse(data, c)
+	if err != nil {
 		return fmt.Errorf("parsing config file: %s", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -34,6 +35,7 @@ var (
 	WebMetricPath      = kingpin.Flag("web.metrics.path", "metric path").Default("/metrics").String()
 	WebConfigFile      = kingpin.Flag("web.config.file", "Path to the web configuration file").Default("").String()
 	configFile         = kingpin.Flag("config.file", "Exporter configuration file").Default("/app/cfg/network_exporter.yml").String()
+	configFileHeaders  = HTTPHeader(kingpin.Flag("config.file.header", "Headers for loading configuration file from URL"))
 	enableProfileing   = kingpin.Flag("profiling", "Enable Profiling (pprof + fgprof)").Default("false").Bool()
 	sc                 = &config.SafeConfig{Cfg: &config.Config{}}
 	logger             *slog.Logger
@@ -45,6 +47,26 @@ var (
 
 	indexHTML = `<!doctype html><html><head> <meta charset="UTF-8"><title>Network Exporter (Version ` + version + `)</title></head><body><h1>Network Exporter</h1><p><a href="%s">Metrics</a></p></body></html>`
 )
+
+type HTTPHeaderValue http.Header
+
+func (h *HTTPHeaderValue) Set(value string) error {
+	parts := strings.SplitN(value, "=", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("expected HEADER=VALUE got '%s'", value)
+	}
+	(*http.Header)(h).Add(parts[0], parts[1])
+	return nil
+}
+
+func (h *HTTPHeaderValue) String() string {
+	return ""
+}
+func HTTPHeader(s kingpin.Settings) (target *http.Header) {
+	target = &http.Header{}
+	s.SetValue((*HTTPHeaderValue)(target))
+	return
+}
 
 func init() {
 	promslogConfig := &promslog.Config{}
@@ -60,7 +82,7 @@ func main() {
 	logger.Info("msg", "Starting network_exporter", "version", version)
 
 	logger.Info("msg", "Loading config")
-	if err := sc.ReloadConfig(logger, *configFile); err != nil {
+	if err := sc.ReloadConfig(logger, *configFile, *configFileHeaders); err != nil {
 		logger.Error("msg", "Loading config", "err", err)
 		os.Exit(1)
 	}
@@ -94,7 +116,7 @@ func startConfigRefresh() {
 
 	for range time.NewTicker(interval).C {
 		logger.Info("msg", "ReLoading config")
-		if err := sc.ReloadConfig(logger, *configFile); err != nil {
+		if err := sc.ReloadConfig(logger, *configFile, *configFileHeaders); err != nil {
 			logger.Error("msg", "Reloading config skipped", "err", err)
 			continue
 		} else {

--- a/signal.go
+++ b/signal.go
@@ -23,7 +23,7 @@ func reloadSignal() {
 			case <-hup:
 				logger.Debug("msg", "Signal: HUP")
 				logger.Info("msg", "ReLoading config")
-				if err := sc.ReloadConfig(logger, *configFile); err != nil {
+				if err := sc.ReloadConfig(logger, *configFile, *configFileHeaders); err != nil {
 					logger.Error("msg", "Reloading config skipped", "err", err)
 					continue
 				} else {

--- a/signal_windows.go
+++ b/signal_windows.go
@@ -20,7 +20,7 @@ func reloadSignal() {
 			case <-hup:
 				logger.Debug("msg", "Signal: HUP")
 				logger.Info("msg", "ReLoading config")
-				if err := sc.ReloadConfig(logger, *configFile); err != nil {
+				if err := sc.ReloadConfig(logger, *configFile, *configFileHeaders); err != nil {
 					logger.Error("msg", "Reloading config skipped", "err", err)
 					continue
 				} else {


### PR DESCRIPTION
One feature of victoria metrics I use heavily is it's ability to load it's configuration from an HTTP endpoint which let's me centrally configure instances easily.

I roughly added that in here